### PR TITLE
fix "attempt to concatenate a nil value" error

### DIFF
--- a/lua/tabline_framework/tabline.lua
+++ b/lua/tabline_framework/tabline.lua
@@ -137,14 +137,14 @@ end
 
 local function icon(name)
   if not name then return end
-  local i = get_icon(name)
+  local i = get_icon(name, nil, {default = true})
   return i
 end
 
 local function icon_color(name)
   if not name then return end
 
-  local _, hl = get_icon(name)
+  local _, hl = get_icon(name, nil, {default = true})
   return hi.get_hl(hl).fg
 end
 


### PR DESCRIPTION
When attempting to get an icon for any filename that doesn't have one configured (a "vimrc" file does this for me for instance), nvim-web-devicons.get_icon() returns `nil`, which then causes errors like the below:

```
E5108: Error executing lua ...k.nvim/lua/tabline_framework/examples/diagonal_tiles.lua:31: attempt to concatenate a nil value
stack traceback:
        ...k.nvim/lua/tabline_framework/examples/diagonal_tiles.lua:31: in function 'callback'
        ...tabline-framework.nvim/lua/tabline_framework/tabline.lua:44: in function 'make_tabs'
        ...tabline-framework.nvim/lua/tabline_framework/tabline.lua:167: in function 'make_tabs'
        ...k.nvim/lua/tabline_framework/examples/diagonal_tiles.lua:21: in function 'render_func'
        ...tabline-framework.nvim/lua/tabline_framework/tabline.lua:156: in function <...tabline-framework.nvim/lua/tabline_framework/tabline.lua:151>
```

This change tells `get_icon` to return some default icon if none is found.
