### PR TITLE
cleanup implementation of add_buf_to_tab

### DIFF
--- a/lua/tabline_framework/toys.lua
+++ b/lua/tabline_framework/toys.lua
@@ -16,17 +16,19 @@ end
 
 local function add_buf_to_tab()
   local tab = vim.api.nvim_get_current_tabpage()
-  local win = vim.api.nvim_tabpage_get_win(tab)
-  local buf = vim.api.nvim_win_get_buf(win)
-  local is_valid = vim.api.nvim_buf_is_valid(buf)
-  local is_listed = vim.api.nvim_buf_get_option(buf, 'buflisted')
-  if not is_valid or not is_listed then return end
+  local windows = vim.api.nvim_tabpage_list_wins(tab)
+  buffers_in_tab = {}
+  for _,v in ipairs(windows) do
+    local buf = vim.api.nvim_win_get_buf(v)
 
-  local list = get_tab_buffers(tab)
-
-  if not vim.tbl_contains(list, buf) then table.insert(list, buf) end
-
-  vim.api.nvim_tabpage_set_var(tab, 'tabline_framework_buffer_list', list)
+    local is_valid = vim.api.nvim_buf_is_valid(buf)
+    local is_listed = vim.api.nvim_buf_get_option(buf, 'buflisted')
+    if is_valid and is_listed then
+      local name = vim.api.nvim_buf_get_name(buf)
+      table.insert(buffers_in_tab, name)
+    end
+  end
+  vim.api.nvim_tabpage_set_var(tab, 'tabline_framework_buffer_list', buffers_in_tab)
 end
 
 


### PR DESCRIPTION
Changed implementation to recalculate the whole contents of `t:tabline_framework_buffer_list` whenever executing instead of trying to keep track of state. Cleaner, less error prone, and in practice seems to be perfectly performant.

This has worked reliably for me so far in several hours of usage. I've been working on my own version of the diagonal_tiles example config that uses this code to show a list of the buffers open in a tab within the tab bar. As noted in the below diff, still have 2 issues to work out. Will get to tha when I next have a bit of spare time.

```diff
diff --git i/lua/tabline_framework/examples/diagonal_tiles.lua w/lua/tabline_framework/examples/diagonal_tiles.lua
index 1707d73..2d96dfc 100644
--- i/lua/tabline_framework/examples/diagonal_tiles.lua
+++ w/lua/tabline_framework/examples/diagonal_tiles.lua
@@ -15,6 +15,8 @@ local colors = {
   fg = '#696969'
 }
 
+local toys = require 'tabline_framework.toys'
+toys.setup_tab_buffers()
 local render = function(f)
   f.add { '  ' }
 
@@ -24,15 +26,30 @@ local render = function(f)
 
     f.add( info.index .. ' ')
 
-    if info.filename then
-      f.add(info.modified and '+')
-      f.add(info.filename)
-      f.add {
-        ' ' .. f.icon(info.filename),
-        fg = info.current and f.icon_color(info.filename) or nil
-      }
-    else
-      f.add(info.modified and '[+]' or '[-]')
+    local current_tab = vim.api.nvim_get_current_tabpage()
+
+    -- TODO:
+    -- 1. need to handle help windows, possibly other unlisted windows?
+    -- when focused, they'll be populated into info.filename or whatever
+    -- but they won't be in the get_tab_buffers list, since they're unlisted buffers
+    -- 2. need to disambiguate if two files are open with the same name by adding components of the path back
+
+    -- info.buf_name is full path to file, info.filename is just the filename (i.e. the tail of the path)
+    for _,bufpath in pairs(toys.get_tab_buffers(info.tab)) do
+        local filename = string.match(bufpath, ".+/(.*)")
+        if info.buf_name and bufpath == info.buf_name and current_tab == info.tab then
+            f.set_fg("#FDB927")
+        end
+        f.add(filename)
+        f.add(info.modified and '+')
+
+        if info.buf_name and bufpath == info.buf_name and current_tab == info.tab then
+          f.set_fg(f.icon_color(filename))
+        end
+        f.add(' ' .. f.icon(filename))
+
+        f.add(' ')
+        f.set_fg(colors.fg)
     end
 
     f.add {
```
